### PR TITLE
Refactor/proxy context

### DIFF
--- a/server/proxy/pf_channels.c
+++ b/server/proxy/pf_channels.c
@@ -73,13 +73,14 @@ static void pf_encomsp_uninit(proxyToServerContext* tf, EncomspClientContext* en
 void pf_OnChannelConnectedEventHandler(void* context,
                                        ChannelConnectedEventArgs* e)
 {
+	proxyToServerContext* proxyToServer = (proxyToServerContext*) context;
+	clientToProxyContext* peer = proxyToServer->peer;
+
 	WLog_DBG(TAG, "Channel connected: %s", e->name);
-	proxyToServerContext* sContext = (proxyToServerContext*) context;
-	clientToProxyContext* cContext = (clientToProxyContext*)((proxyContext*) context)->peerContext;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
-		sContext->rdpei = (RdpeiClientContext*) e->pInterface;
+		proxyToServer->rdpei = (RdpeiClientContext*) e->pInterface;
 	}
 	else if (strcmp(e->name, TSMF_DVC_CHANNEL_NAME) == 0)
 	{
@@ -87,7 +88,7 @@ void pf_OnChannelConnectedEventHandler(void* context,
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
 		RdpgfxClientContext* gfx = (RdpgfxClientContext*) e->pInterface;
-		RdpgfxServerContext* server = cContext->gfx;
+		RdpgfxServerContext* server = peer->gfx;
 		proxy_graphics_pipeline_init(gfx, server);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)
@@ -98,7 +99,7 @@ void pf_OnChannelConnectedEventHandler(void* context,
 	}
 	else if (strcmp(e->name, ENCOMSP_SVC_CHANNEL_NAME) == 0)
 	{
-		pf_encomsp_init(sContext, (EncomspClientContext*) e->pInterface);
+		pf_encomsp_init(proxyToServer, (EncomspClientContext*) e->pInterface);
 	}
 }
 
@@ -106,8 +107,6 @@ void pf_OnChannelDisconnectedEventHandler(void* context,
         ChannelDisconnectedEventArgs* e)
 {
 	proxyToServerContext* proxyToServer = (proxyToServerContext*) context;
-	rdpSettings* settings;
-	settings = ((rdpContext*)proxyToServer)->settings;
 
 	if (strcmp(e->name, RDPEI_DVC_CHANNEL_NAME) == 0)
 	{
@@ -118,7 +117,7 @@ void pf_OnChannelDisconnectedEventHandler(void* context,
 	}
 	else if (strcmp(e->name, RDPGFX_DVC_CHANNEL_NAME) == 0)
 	{
-		gdi_graphics_pipeline_uninit(((rdpContext*)proxyToServer)->gdi,
+		gdi_graphics_pipeline_uninit(proxyToServer->c.gdi,
 		                             (RdpgfxClientContext*) e->pInterface);
 	}
 	else if (strcmp(e->name, RAIL_SVC_CHANNEL_NAME) == 0)

--- a/server/proxy/pf_common.c
+++ b/server/proxy/pf_common.c
@@ -1,9 +1,24 @@
-#include "pf_common.h"
+/**
+ * FreeRDP: A Remote Desktop Protocol Implementation
+ * FreeRDP Proxy Server
+ *
+ * Copyright 2019 Mati Shabtay <matishabtay@gmail.com>
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-BOOL pf_common_connection_aborted_by_peer(proxyContext* context)
-{
-	return WaitForSingleObject(context->connectionClosed, 0) == WAIT_OBJECT_0;
-}
+#include "pf_common.h"
 
 void pf_common_copy_settings(rdpSettings* dst, rdpSettings* src)
 {

--- a/server/proxy/pf_common.h
+++ b/server/proxy/pf_common.h
@@ -24,7 +24,6 @@
 #include <freerdp/freerdp.h>
 #include "pf_context.h"
 
-BOOL pf_common_connection_aborted_by_peer(proxyContext* context);
 void pf_common_copy_settings(rdpSettings* dst, rdpSettings* src);
 
 #endif /* FREERDP_SERVER_PROXY_PFCOMMON_H */

--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -55,7 +55,7 @@ BOOL init_client_to_proxy_context(freerdp_peer* client)
 	return freerdp_peer_context_new(client);
 }
 
-rdpContext* proxy_to_server_context_create(rdpSettings* clientSettings,
+proxyToServerContext* proxy_to_server_context_create(rdpSettings* clientSettings,
         char* host, DWORD port)
 {
 	RDP_CLIENT_ENTRY_POINTS clientEntryPoints;
@@ -75,5 +75,5 @@ rdpContext* proxy_to_server_context_create(rdpSettings* clientSettings,
 	settings->ServerPort = port;
 	settings->SoftwareGdi = FALSE;
 	settings->RedirectClipboard = FALSE;
-	return context;
+	return (proxyToServerContext*)context;
 }

--- a/server/proxy/pf_context.h
+++ b/server/proxy/pf_context.h
@@ -28,39 +28,30 @@
 #include <freerdp/client/rdpgfx.h>
 #include <freerdp/server/rdpgfx.h>
 
-/**
- * Proxy context wraps a peer's context, and holds a reference to the other end
- * of the connection. This lets one side of the proxy to forward events to the
- * other.
- */
-struct proxy_context
-{
-	/* Context of client or server */
-	rdpContext _context;
-
-	/**
-	 * Context of peer to which the proxy is connected.
-	 * Events from the first context are forwarded to this one.
-	 */
-	rdpContext* peerContext;
-
-	HANDLE connectionClosed;
-};
-typedef struct proxy_context proxyContext;
+typedef struct client_to_proxy_context clientToProxyContext;
+typedef struct proxy_to_server_context proxyToServerContext;
 
 /**
  * Context used for the client's connection to the proxy.
  */
 struct client_to_proxy_context
 {
-	proxyContext _context;
+	/* Underlying context of the client connection */
+	rdpContext c;
 
+	/**
+	 * Context of the proxy's connection to the target server.
+	 * Events from the client's context are forwarded to this one.
+	 */
+	proxyToServerContext* peer;
+	HANDLE connectionClosed;
+
+	/* Client to proxy related context */
 	HANDLE vcm;
 	HANDLE thread;
 
 	RdpgfxServerContext* gfx;
 };
-typedef struct client_to_proxy_context clientToProxyContext;
 
 BOOL init_client_to_proxy_context(freerdp_peer* client);
 
@@ -69,14 +60,22 @@ BOOL init_client_to_proxy_context(freerdp_peer* client);
  */
 struct proxy_to_server_context
 {
-	proxyContext _context;
+	/* Underlying context of the server connection */
+	rdpContext c;
+
+	/**
+	 * Context of the proxy's connection to the client.
+	 * Events from the server's context are forwarded to this one.
+	 */
+	clientToProxyContext* peer;
+	HANDLE connectionClosed;
 
 	RdpeiClientContext* rdpei;
 	RdpgfxClientContext* gfx;
 	EncomspClientContext* encomsp;
 };
-typedef struct proxy_to_server_context proxyToServerContext;
 
-rdpContext* proxy_to_server_context_create(rdpSettings* clientSettings, char* host, DWORD port);
+proxyToServerContext* proxy_to_server_context_create(rdpSettings* clientSettings, char* host,
+        DWORD port);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONTEXT_H */

--- a/server/proxy/pf_graphics.c
+++ b/server/proxy/pf_graphics.c
@@ -1,10 +1,9 @@
 /**
  * FreeRDP: A Remote Desktop Protocol Implementation
- * X11 Graphical Objects
+ * FreeRDP Proxy Server
  *
- * Copyright 2011 Marc-Andre Moreau <marcandre.moreau@gmail.com>
- * Copyright 2016 Thincast Technologies GmbH
- * Copyright 2016 Armin Novak <armin.novak@thincast.com>
+ * Copyright 2019 Mati Shabtay <matishabtay@gmail.com>
+ * Copyright 2019 Kobi Mizrachi <kmizrachi18@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/server/proxy/pf_input.c
+++ b/server/proxy/pf_input.c
@@ -23,37 +23,35 @@
 
 BOOL pf_server_synchronize_event(rdpInput* input, UINT32 flags)
 {
-	proxyContext* context = (proxyContext*)input->context;
-	return freerdp_input_send_synchronize_event(context->peerContext->input,
-	        flags);
+	clientToProxyContext* context = (clientToProxyContext*)input->context;
+	return freerdp_input_send_synchronize_event(context->peer->c.input, flags);
 }
 
 BOOL pf_server_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
-	proxyContext* context = (proxyContext*)input->context;
-	return freerdp_input_send_keyboard_event(context->peerContext->input,
-	        flags, code);
+	clientToProxyContext* context = (clientToProxyContext*)input->context;
+	return freerdp_input_send_keyboard_event(context->peer->c.input, flags,
+	        code);
 }
 
 BOOL pf_server_unicode_keyboard_event(rdpInput* input, UINT16 flags, UINT16 code)
 {
-	proxyContext* context = (proxyContext*)input->context;
-	return freerdp_input_send_unicode_keyboard_event(context->peerContext->input,
+	clientToProxyContext* context = (clientToProxyContext*)input->context;
+	return freerdp_input_send_unicode_keyboard_event(context->peer->c.input,
 	        flags, code);
 }
 
 BOOL pf_server_mouse_event(rdpInput* input, UINT16 flags, UINT16 x, UINT16 y)
 {
-	proxyContext* context = (proxyContext*)input->context;
-	return freerdp_input_send_mouse_event(context->peerContext->input,
-	                                      flags, x, y);
+	clientToProxyContext* context = (clientToProxyContext*)input->context;
+	return freerdp_input_send_mouse_event(context->peer->c.input, flags, x, y);
 }
 
 BOOL pf_server_extended_mouse_event(rdpInput* input, UINT16 flags, UINT16 x,
                                     UINT16 y)
 {
-	proxyContext* context = (proxyContext*)input->context;
-	return freerdp_input_send_extended_mouse_event(context->peerContext->input,
+	clientToProxyContext* context = (clientToProxyContext*)input->context;
+	return freerdp_input_send_extended_mouse_event(context->peer->c.input,
 	        flags, x, y);
 }
 

--- a/server/proxy/pf_update.c
+++ b/server/proxy/pf_update.c
@@ -24,17 +24,17 @@
 BOOL pf_server_refresh_rect(rdpContext* context, BYTE count,
                             const RECTANGLE_16* areas)
 {
-	proxyContext* pContext = (proxyContext*) context;
-	return pContext->peerContext->update->RefreshRect(pContext->peerContext,
-	        count, areas);
+	clientToProxyContext* clientToProxy = (clientToProxyContext*) context;
+	proxyToServerContext* peer = clientToProxy->peer;
+	return peer->c.update->RefreshRect(&peer->c, count, areas);
 }
 
 BOOL pf_server_suppress_output(rdpContext* context, BYTE allow,
                                const RECTANGLE_16* area)
 {
-	proxyContext* pContext = (proxyContext*) context;
-	return pContext->peerContext->update->SuppressOutput(pContext->peerContext,
-	        allow, area);
+	clientToProxyContext* clientToProxy = (clientToProxyContext*) context;
+	proxyToServerContext* peer = clientToProxy->peer;
+	return peer->c.update->SuppressOutput(&peer->c, allow, area);
 }
 
 void register_update_callbacks(rdpUpdate* update)


### PR DESCRIPTION
Just a refactor, no change in functionality. The constant casting of pointers when dealing with context was annoying boilerplate code I wanted to minimize and simplify, so I took away the common `proxyContext` abstraction and renamed the underlying rdpContext to `c` for short.

Now, in a context of a function, the context of the side the method is in (I.E. `clientToProxy` in `pf_server.c` or `proxyToServer` in `pf_client.c`) will be called `context`, and the other side of the connection will be called `peer`. In case the name `context` is already taken (in a case of a parameter to the function named `context` that needs casting), the shorthand `ctx` can be used.