### PR TITLE
Add target in config. Add checks for configuration validity

### DIFF
--- a/server/proxy/config.ini
+++ b/server/proxy/config.ini
@@ -1,6 +1,6 @@
 [Server]
 Host = "0.0.0.0"
-Port = -3289
+Port = 3289
 LocalOnly = 0
 
 [Target]

--- a/server/proxy/config.ini
+++ b/server/proxy/config.ini
@@ -1,7 +1,15 @@
 [Server]
 Host = "0.0.0.0"
-Port = 3289
+Port = -3289
 LocalOnly = 0
+
+[Target]
+; If this value is set to TRUE, the target server info will be parsed from 
+; /load-balance-info option at runtime. Otherwise, the server will always connect to the same target,
+; Using the hardcoded values of `Host` and `Port` under this configuration section.
+UseLoadBalanceInfo = 1
+Host = "kubistika89"
+Port = 2289
 
 [Input]
 Mouse = 1
@@ -17,6 +25,6 @@ TlsSupport = 0
 RdpSupport = 0
 
 [Channels]
-Mode = 1 # 0 = Whitelist, 1 = Blacklist
+WhitelistMode = 0
 AllowedChannels = "cliprdr,Microsoft::Windows::RDS::Video::Control"
 DeniedChannels = "Microsoft::Windows::RDS::Geometry"

--- a/server/proxy/pf_config.h
+++ b/server/proxy/pf_config.h
@@ -21,14 +21,23 @@
 #ifndef FREERDP_SERVER_PROXY_PFCONFIG_H
 #define FREERDP_SERVER_PROXY_PFCONFIG_H
 
+#define CONFIG_PARSE_SUCCESS 0
+#define CONFIG_PARSE_ERROR 	 1
+#define CONFIG_INVALID 		 2
+
 #include <winpr/ini.h>
 
 struct proxy_config
 {
 	/* server */
 	char* Host;
-	UINT16 Port;
+	INT32 Port;
 	BOOL  LocalOnly;
+
+	/* target */
+	BOOL UseLoadBalanceInfo;
+	char* TargetHost;
+	INT32 TargetPort;
 
 	/* graphics */
 	BOOL GFX;
@@ -55,7 +64,7 @@ struct proxy_config
 
 typedef struct proxy_config proxyConfig;
 
-BOOL pf_server_load_config(char* path, proxyConfig* config);
+DWORD pf_server_load_config(char* path, proxyConfig* config);
 void pf_server_config_free(proxyConfig* config);
 
 #endif /* FREERDP_SERVER_PROXY_PFCONFIG_H */

--- a/server/proxy/pfreerdp.c
+++ b/server/proxy/pfreerdp.c
@@ -37,12 +37,20 @@ int main(int argc, char* argv[])
 	}
 
 	config = server->config;
+	status = pf_server_load_config("config.ini", config);
 
-	if (!pf_server_load_config("config.ini", config))
+	switch (status)
 	{
-		WLog_ERR(TAG, "An error occured while parsing configuration file");
-		status = -1;
-		goto fail;
+		case CONFIG_PARSE_SUCCESS:
+			WLog_DBG(TAG, "Configuration parsed successfully");
+			break;
+
+		case CONFIG_PARSE_ERROR:
+			WLog_ERR(TAG, "An error occured while parsing configuration file, exiting...");
+			goto fail;
+
+		case CONFIG_INVALID:
+			goto fail;
 	}
 
 	if (config->WhitelistMode)

--- a/server/proxy/proxy.c
+++ b/server/proxy/proxy.c
@@ -19,6 +19,8 @@ rdpProxyServer* proxy_server_new()
 
 void proxy_server_free(rdpProxyServer* server)
 {
-	pf_server_config_free(server->config);
+	if (server->config)
+		pf_server_config_free(server->config);
+		
 	free(server);
 }


### PR DESCRIPTION
This PR adds some checks for configuration validity and an option to supply target host information directly from configuration.