### PR TITLE
Bugfix/rdpgfx server 10.6 new messages

### DIFF
--- a/channels/rdpgfx/client/rdpgfx_main.c
+++ b/channels/rdpgfx/client/rdpgfx_main.c
@@ -1204,7 +1204,7 @@ static UINT rdpgfx_recv_map_surface_to_scaled_output_pdu(RDPGFX_CHANNEL_CALLBACK
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
 
-	if (Stream_GetRemainingLength(s) < 12)
+	if (Stream_GetRemainingLength(s) < 20)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
@@ -1214,11 +1214,11 @@ static UINT rdpgfx_recv_map_surface_to_scaled_output_pdu(RDPGFX_CHANNEL_CALLBACK
 	Stream_Read_UINT16(s, pdu.reserved); /* reserved (2 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginX); /* outputOriginX (4 bytes) */
 	Stream_Read_UINT32(s, pdu.outputOriginY); /* outputOriginY (4 bytes) */
-	Stream_Read_UINT32(s, pdu.targetX);
-	Stream_Read_UINT32(s, pdu.targetY);
+	Stream_Read_UINT32(s, pdu.targetWidth); /* targetWidth (4 bytes) */
+	Stream_Read_UINT32(s, pdu.targetHeight); /* targetHeight (4 bytes) */
 	WLog_Print(gfx->log, WLOG_DEBUG,
-	           "RecvMapSurfaceToOutputPdu: surfaceId: %"PRIu16" outputOriginX: %"PRIu32" outputOriginY: %"PRIu32" targetX: %"PRIu32" targetY: %"PRIu32,
-	           pdu.surfaceId, pdu.outputOriginX, pdu.outputOriginY, pdu.targetX, pdu.targetY);
+	           "RecvMapSurfaceToScaledOutputPdu: surfaceId: %"PRIu16" outputOriginX: %"PRIu32" outputOriginY: %"PRIu32" targetWidth: %"PRIu32" targetHeight: %"PRIu32,
+	           pdu.surfaceId, pdu.outputOriginX, pdu.outputOriginY, pdu.targetWidth, pdu.targetHeight);
 
 	if (context)
 	{
@@ -1245,7 +1245,7 @@ static UINT rdpgfx_recv_map_surface_to_window_pdu(RDPGFX_CHANNEL_CALLBACK* callb
 	RdpgfxClientContext* context = (RdpgfxClientContext*) gfx->iface.pInterface;
 	UINT error = CHANNEL_RC_OK;
 
-	if (Stream_GetRemainingLength(s) < 18)
+	if (Stream_GetRemainingLength(s) < 26)
 	{
 		WLog_Print(gfx->log, WLOG_ERROR, "not enough data!");
 		return ERROR_INVALID_DATA;
@@ -1288,11 +1288,11 @@ static UINT rdpgfx_recv_map_surface_to_scaled_window_pdu(RDPGFX_CHANNEL_CALLBACK
 	Stream_Read_UINT64(s, pdu.windowId); /* windowId (8 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedWidth); /* mappedWidth (4 bytes) */
 	Stream_Read_UINT32(s, pdu.mappedHeight); /* mappedHeight (4 bytes) */
-	Stream_Read_UINT32(s, pdu.targetWidth);
-	Stream_Read_UINT32(s, pdu.targetHeight);
+	Stream_Read_UINT32(s, pdu.targetWidth); /* targetWidth (4 bytes) */
+	Stream_Read_UINT32(s, pdu.targetHeight); /* targetHeight (4 bytes) */
 	WLog_Print(gfx->log, WLOG_DEBUG,
-	           "RecvMapSurfaceToWindowPdu: surfaceId: %"PRIu16" windowId: 0x%016"PRIX64" mappedWidth: %"PRIu32" mappedHeight: %"PRIu32"",
-	           pdu.surfaceId, pdu.windowId, pdu.mappedWidth, pdu.mappedHeight);
+	           "RecvMapSurfaceToScaledWindowPdu: surfaceId: %"PRIu16" windowId: 0x%016"PRIX64" mappedWidth: %"PRIu32" mappedHeight: %"PRIu32" targetWidth: %"PRIu32" targetHeight: %"PRIu32"",
+	           pdu.surfaceId, pdu.windowId, pdu.mappedWidth, pdu.mappedHeight, pdu.targetWidth, pdu.targetHeight);
 
 	if (context && context->MapSurfaceToScaledWindow)
 	{

--- a/channels/rdpgfx/server/rdpgfx_main.c
+++ b/channels/rdpgfx/server/rdpgfx_main.c
@@ -1065,7 +1065,7 @@ static UINT rdpgfx_send_map_surface_to_scaled_window_pdu(RdpgfxServerContext* co
         RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
-	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 18);
+	                 RDPGFX_CMDID_MAPSURFACETOWINDOW, 26);
 
 	if (!s)
 	{
@@ -1077,8 +1077,8 @@ static UINT rdpgfx_send_map_surface_to_scaled_window_pdu(RdpgfxServerContext* co
 	Stream_Write_UINT64(s, pdu->windowId); /* windowId (8 bytes) */
 	Stream_Write_UINT32(s, pdu->mappedWidth); /* mappedWidth (4 bytes) */
 	Stream_Write_UINT32(s, pdu->mappedHeight); /* mappedHeight (4 bytes) */
-	Stream_Write_UINT32(s, pdu->targetWidth);
-	Stream_Write_UINT32(s, pdu->targetHeight);
+	Stream_Write_UINT32(s, pdu->targetWidth); /* targetWidth (4 bytes) */
+	Stream_Write_UINT32(s, pdu->targetHeight); /* targetHeight  (4 bytes) */
 	return rdpgfx_server_single_packet_send(context, s);
 }
 
@@ -1101,8 +1101,7 @@ static UINT rdpgfx_recv_frame_acknowledge_pdu(RdpgfxServerContext* context,
 
 	Stream_Read_UINT32(s, pdu.queueDepth); /* queueDepth (4 bytes) */
 	Stream_Read_UINT32(s, pdu.frameId); /* frameId (4 bytes) */
-	/* totalFramesDecoded (4 bytes) */
-	Stream_Read_UINT32(s, pdu.totalFramesDecoded);
+	Stream_Read_UINT32(s, pdu.totalFramesDecoded); /* totalFramesDecoded (4 bytes) */
 
 	if (context)
 	{
@@ -1284,7 +1283,7 @@ static UINT rdpgfx_send_map_surface_to_scaled_output_pdu(RdpgfxServerContext* co
         RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* pdu)
 {
 	wStream* s = rdpgfx_server_single_packet_new(
-	                 RDPGFX_CMDID_MAPSURFACETOSCALEDOUTPUT, 12);
+	                 RDPGFX_CMDID_MAPSURFACETOSCALEDOUTPUT, 20);
 
 	if (!s)
 	{
@@ -1296,8 +1295,8 @@ static UINT rdpgfx_send_map_surface_to_scaled_output_pdu(RdpgfxServerContext* co
 	Stream_Write_UINT16(s, 0); /* reserved (2 bytes). Must be 0 */
 	Stream_Write_UINT32(s, pdu->outputOriginX); /* outputOriginX (4 bytes) */
 	Stream_Write_UINT32(s, pdu->outputOriginY); /* outputOriginY (4 bytes) */
-	Stream_Write_UINT32(s, pdu->targetX);
-	Stream_Write_UINT32(s, pdu->targetY);
+	Stream_Write_UINT32(s, pdu->targetWidth); /* targetWidth (4 bytes) */
+	Stream_Write_UINT32(s, pdu->targetHeight); /* targetHeight (4 bytes) */
 	return rdpgfx_server_single_packet_send(context, s);
 }
 

--- a/include/freerdp/channels/rdpgfx.h
+++ b/include/freerdp/channels/rdpgfx.h
@@ -321,8 +321,8 @@ struct _RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU
 	UINT16 reserved;
 	UINT32 outputOriginX;
 	UINT32 outputOriginY;
-	UINT32 targetX;
-	UINT32 targetY;
+	UINT32 targetWidth;
+	UINT32 targetHeight;
 };
 typedef struct _RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU
 	RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU;

--- a/server/proxy/pf_rdpgfx.c
+++ b/server/proxy/pf_rdpgfx.c
@@ -32,81 +32,82 @@
 static UINT pf_rdpgfx_reset_graphics(RdpgfxClientContext* context,
                                      const RDPGFX_RESET_GRAPHICS_PDU* resetGraphics)
 {
-	WLog_DBG(TAG, "ResetGraphics");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->ResetGraphics(server, resetGraphics);
 }
 
 static UINT pf_rdpgfx_start_frame(RdpgfxClientContext* context,
                                   const RDPGFX_START_FRAME_PDU* startFrame)
 {
-	WLog_DBG(TAG, "StartFrame");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->StartFrame(server, startFrame);
 }
 
 static UINT pf_rdpgfx_end_frame(RdpgfxClientContext* context,
                                 const RDPGFX_END_FRAME_PDU* endFrame)
 {
-	WLog_DBG(TAG, "EndFrame");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->EndFrame(server, endFrame);
 }
 
 static UINT pf_rdpgfx_surface_command(RdpgfxClientContext* context,
                                       const RDPGFX_SURFACE_COMMAND* cmd)
 {
-	WLog_DBG(TAG, "SurfaceCommand");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->SurfaceCommand(server, cmd);
 }
 
 static UINT pf_rdpgfx_delete_encoding_context(RdpgfxClientContext* context,
         const RDPGFX_DELETE_ENCODING_CONTEXT_PDU* deleteEncodingContext)
 {
-	WLog_DBG(TAG, "DeleteEncodingContext");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->DeleteEncodingContext(server, deleteEncodingContext);
 }
 
 static UINT pf_rdpgfx_create_surface(RdpgfxClientContext* context,
                                      const RDPGFX_CREATE_SURFACE_PDU* createSurface)
 {
-	WLog_DBG(TAG, "CreateSurface");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->CreateSurface(server, createSurface);
 }
 
 static UINT pf_rdpgfx_delete_surface(RdpgfxClientContext* context,
                                      const RDPGFX_DELETE_SURFACE_PDU* deleteSurface)
 {
-	WLog_DBG(TAG, "DeleteSurface");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->DeleteSurface(server, deleteSurface);
 }
 
 static UINT pf_rdpgfx_solid_fill(RdpgfxClientContext* context,
                                  const RDPGFX_SOLID_FILL_PDU* solidFill)
 {
-	WLog_DBG(TAG, "SolidFill");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->SolidFill(server, solidFill);
 }
 
 static UINT pf_rdpgfx_surface_to_surface(RdpgfxClientContext* context,
         const RDPGFX_SURFACE_TO_SURFACE_PDU* surfaceToSurface)
 {
-	WLog_DBG(TAG, "SurfaceToSurface");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->SurfaceToSurface(server, surfaceToSurface);
 }
 
@@ -116,60 +117,80 @@ static UINT pf_rdpgfx_surface_to_cache(RdpgfxClientContext* context,
 	WLog_DBG(TAG, "SurfaceToCache");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->SurfaceToCache(server, surfaceToCache);
 }
 
 static UINT pf_rdpgfx_cache_to_surface(RdpgfxClientContext* context,
                                        const RDPGFX_CACHE_TO_SURFACE_PDU* cacheToSurface)
 {
-	WLog_DBG(TAG, "CacheToSurface");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->CacheToSurface(server, cacheToSurface);
 }
 
 static UINT pf_rdpgfx_cache_import_reply(RdpgfxClientContext* context,
         const RDPGFX_CACHE_IMPORT_REPLY_PDU* cacheImportReply)
 {
-	WLog_DBG(TAG, "CacheImportReply");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->CacheImportReply(server, cacheImportReply);
 }
 
 static UINT pf_rdpgfx_evict_cache_entry(RdpgfxClientContext* context,
                                         const RDPGFX_EVICT_CACHE_ENTRY_PDU* evictCacheEntry)
 {
-	WLog_DBG(TAG, "EvictCacheEntry");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->EvictCacheEntry(server, evictCacheEntry);
 }
 
 static UINT pf_rdpgfx_map_surface_to_output(RdpgfxClientContext* context,
         const RDPGFX_MAP_SURFACE_TO_OUTPUT_PDU* surfaceToOutput)
 {
-	WLog_DBG(TAG, "MapSurfaceToOutput");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->MapSurfaceToOutput(server, surfaceToOutput);
 }
 
 static UINT pf_rdpgfx_map_surface_to_window(RdpgfxClientContext* context,
         const RDPGFX_MAP_SURFACE_TO_WINDOW_PDU* surfaceToWindow)
 {
-	WLog_DBG(TAG, "MapSurfaceToWindow");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->MapSurfaceToWindow(server, surfaceToWindow);
 }
 
-static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context, BOOL* do_caps_advertise,
-                              BOOL* send_frame_acks)
+static UINT pf_rdpgfx_map_surface_to_scaled_window(RdpgfxClientContext* context,
+        const RDPGFX_MAP_SURFACE_TO_SCALED_WINDOW_PDU* surfaceToScaledWindow)
 {
-	WLog_DBG(TAG, "OnOpen");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
+	return server->MapSurfaceToScaledWindow(server, surfaceToScaledWindow);
+}
+
+
+static UINT pf_rdpgfx_map_surface_to_scaled_output(RdpgfxClientContext* context,
+        const RDPGFX_MAP_SURFACE_TO_SCALED_OUTPUT_PDU* surfaceToScaledOutput)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
+	return server->MapSurfaceToScaledOutput(server, surfaceToScaledOutput);
+}
+
+static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context,
+                              BOOL* do_caps_advertise, BOOL* send_frame_acks)
+{
+	proxyData* pdata = (proxyData*) context->custom;
+	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 
 	if (NULL != do_caps_advertise)
 		*do_caps_advertise = FALSE;
@@ -193,18 +214,18 @@ static UINT pf_rdpgfx_on_open(RdpgfxClientContext* context, BOOL* do_caps_advert
 
 static UINT pf_rdpgfx_on_close(RdpgfxClientContext* context)
 {
-	WLog_DBG(TAG, "OnClose");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->Close(server);
 }
 
 static UINT pf_rdpgfx_caps_confirm(RdpgfxClientContext* context,
                                    RDPGFX_CAPS_CONFIRM_PDU* capsConfirm)
 {
-	WLog_DBG(TAG, "CapsConfirm");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxServerContext* server = (RdpgfxServerContext*) pdata->ps->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return server->CapsConfirm(server, capsConfirm);
 }
 
@@ -212,7 +233,6 @@ static UINT pf_rdpgfx_caps_confirm(RdpgfxClientContext* context,
 static UINT pf_rdpgfx_caps_advertise(RdpgfxServerContext* context,
                                      RDPGFX_CAPS_ADVERTISE_PDU* capsAdvertise)
 {
-	WLog_DBG(TAG, "CapsAdvertise");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxClientContext* client = (RdpgfxClientContext*) pdata->pc->gfx;
 	int index;
@@ -240,16 +260,16 @@ static UINT pf_rdpgfx_caps_advertise(RdpgfxServerContext* context,
 
 	supportedCapsAdvertise.capsSetCount = proxySupportedCapsSetCount;
 	supportedCapsAdvertise.capsSets = proxySupportedCapsSets;
-	WLog_DBG(TAG, "pf_rdpgfx_caps_advertise, sending caps advertise to target");
+	WLog_DBG(TAG, __FUNCTION__);
 	return client->CapsAdvertise(client, &supportedCapsAdvertise);
 }
 
 static UINT pf_rdpgfx_frame_acknowledge(RdpgfxServerContext* context,
                                         RDPGFX_FRAME_ACKNOWLEDGE_PDU* frameAcknowledge)
 {
-	WLog_DBG(TAG, "FrameAck");
 	proxyData* pdata = (proxyData*) context->custom;
 	RdpgfxClientContext* client = (RdpgfxClientContext*) pdata->pc->gfx;
+	WLog_DBG(TAG, __FUNCTION__);
 	return client->FrameAcknowledge(client, frameAcknowledge);
 }
 
@@ -275,6 +295,8 @@ void pf_rdpgfx_pipeline_init(RdpgfxClientContext* gfx, RdpgfxServerContext* serv
 	gfx->EvictCacheEntry = pf_rdpgfx_evict_cache_entry;
 	gfx->MapSurfaceToOutput = pf_rdpgfx_map_surface_to_output;
 	gfx->MapSurfaceToWindow = pf_rdpgfx_map_surface_to_window;
+    gfx->MapSurfaceToScaledOutput = pf_rdpgfx_map_surface_to_scaled_output;
+    gfx->MapSurfaceToScaledWindow = pf_rdpgfx_map_surface_to_scaled_window;
 	gfx->OnOpen = pf_rdpgfx_on_open;
 	gfx->OnClose = pf_rdpgfx_on_close;
 	gfx->CapsConfirm = pf_rdpgfx_caps_confirm;


### PR DESCRIPTION
This PR fixes GFX proxying when GFX version 10.6 is being used.
* Fixes parsing of `rdpgfx_recv_map_surface_to_scaled_ window_pdu`, `rdpgfx_recv_map_surface_to_scaled_output`.
* Fixes wrong names, according to the spec.
* Fixes parsing on client side (minimum data size for those messages was wrong).