### PR TITLE
server/proxy: Fix free invalid memory

### DIFF
--- a/server/proxy/pf_context.c
+++ b/server/proxy/pf_context.c
@@ -90,14 +90,14 @@ static void pf_context_connection_info_free(connectionInfo* info)
 
 proxyData* pf_context_proxy_data_new()
 {
-	proxyData* pdata = malloc(sizeof(proxyData));
+	proxyData* pdata = calloc(1, sizeof(proxyData));
 
 	if (pdata == NULL)
 	{
 		return NULL;
 	}
 
-	pdata->info = malloc(sizeof(connectionInfo));
+	pdata->info = calloc(1, sizeof(connectionInfo));
 
 	if (pdata->info == NULL)
 	{


### PR DESCRIPTION
This PR fixes a segfault when `pf_server_parse_target_from_routing_token` fails. It happens because at the end of the connection, the server frees the `connectionInfo` struct (that points to invalid memory, because it hasn't been set, because parsing the `TargetHostname` failed). This PR just makes sure that the new memory is zeroed and can be freed even when it is not set before.